### PR TITLE
feat: add docker healtheck endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ services:
       - 3000:3000
     volumes:
       - ./data:/app/data
+    # Optional healthcheck
+    healthcheck:
+      test: 'curl -f http://localhost:3000/health'
+      interval: 1m30s
+      timeout: 5s
+      retries: 2
+      start_period: 10s
 ```
 
 Access Svelocker UI on http://dockerip:3000

--- a/src/routes/health/+server.ts
+++ b/src/routes/health/+server.ts
@@ -1,0 +1,5 @@
+import { json } from '@sveltejs/kit';
+
+export async function GET() {
+	return json({ status: 'HEALTHY' }, { status: 200 });
+}


### PR DESCRIPTION
## Summary by Sourcery

Adds a healthcheck endpoint and configures it in the docker-compose file.

New Features:
- Adds a new `/health` endpoint that returns a 200 status code and a JSON body with the status `HEALTHY`.

Deployment:
- Adds a healthcheck configuration to the Docker Compose file, which uses the new `/health` endpoint to determine the health of the service.