### PR TITLE
feat: add registry health/api version check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ src/routes/*.old
 
 test-results/*
 test-results
+tests/.*
 
 node_modules
 

--- a/src/lib/utils/health.ts
+++ b/src/lib/utils/health.ts
@@ -1,0 +1,69 @@
+import axios from 'axios';
+import { Buffer } from 'buffer';
+import { env } from '$env/dynamic/public';
+
+export type HealthStatus = {
+	isHealthy: boolean;
+	supportsV2: boolean;
+	needsAuth: boolean;
+	message: string;
+};
+
+export async function checkRegistryHealth(registryUrl: string): Promise<HealthStatus> {
+	try {
+		const auth = Buffer.from(`${env.PUBLIC_REGISTRY_USERNAME}:${env.PUBLIC_REGISTRY_PASSWORD}`).toString('base64');
+
+		const response = await axios.get(`${registryUrl}/v2/`, {
+			headers: {
+				Authorization: `Basic ${auth}`,
+				Accept: 'application/json'
+			},
+			validateStatus: (status) => [200, 401, 404].includes(status)
+		});
+
+		const apiVersion = response.headers['docker-distribution-api-version'];
+
+		// Handle different response scenarios
+		if (response.status === 200 && apiVersion === 'registry/2.0') {
+			return {
+				isHealthy: true,
+				supportsV2: true,
+				needsAuth: false,
+				message: 'Registry is healthy and supports V2 API'
+			};
+		}
+
+		if (response.status === 401) {
+			const authHeader = response.headers['www-authenticate'];
+			return {
+				isHealthy: true,
+				supportsV2: apiVersion === 'registry/2.0',
+				needsAuth: true,
+				message: 'Registry requires authentication'
+			};
+		}
+
+		if (response.status === 404) {
+			return {
+				isHealthy: false,
+				supportsV2: false,
+				needsAuth: false,
+				message: 'Registry does not support V2 API'
+			};
+		}
+
+		return {
+			isHealthy: false,
+			supportsV2: false,
+			needsAuth: false,
+			message: 'Unexpected registry response'
+		};
+	} catch (error) {
+		return {
+			isHealthy: false,
+			supportsV2: false,
+			needsAuth: false,
+			message: 'Failed to connect to registry'
+		};
+	}
+}

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -5,12 +5,21 @@ import { RegistryCache } from '$lib/services/db';
 import { Logger } from '$lib/services/logger';
 import { checkRegistryHealth } from '$lib/utils/health';
 
-const logger = Logger.getInstance('LayoutServer');
-
 export async function load({ url }) {
+	const logger = Logger.getInstance('LayoutServer');
+
 	// Mock data for tests based on URL parameter
 	if (process.env.PLAYWRIGHT === 'true') {
 		const mockType = url.searchParams.get('mock');
+		logger.debug('Using mock type:', mockType);
+
+		// Mock health status for tests
+		const mockHealthStatus = {
+			isHealthy: mockType !== 'error',
+			supportsV2: true,
+			needsAuth: false,
+			message: mockType === 'error' ? 'Failed to connect to registry' : 'Registry is healthy'
+		};
 
 		switch (mockType) {
 			case 'basic':
@@ -29,7 +38,8 @@ export async function load({ url }) {
 							}
 						]
 					},
-					error: null
+					error: null,
+					healthStatus: mockHealthStatus
 				};
 
 			case 'search':
@@ -53,7 +63,8 @@ export async function load({ url }) {
 							}
 						]
 					},
-					error: null
+					error: null,
+					healthStatus: mockHealthStatus
 				};
 
 			case 'pagination':
@@ -69,19 +80,22 @@ export async function load({ url }) {
 				}));
 				return {
 					repos: { repositories },
-					error: null
+					error: null,
+					healthStatus: mockHealthStatus
 				};
 
 			case 'error':
 				return {
 					repos: { repositories: [] },
-					error: 'Failed to connect to registry'
+					error: 'Failed to connect to registry',
+					healthStatus: mockHealthStatus
 				};
 
 			case 'empty':
 				return {
 					repos: { repositories: [] },
-					error: null
+					error: null,
+					healthStatus: mockHealthStatus
 				};
 
 			default:
@@ -101,7 +115,8 @@ export async function load({ url }) {
 							}
 						]
 					},
-					error: null
+					error: null,
+					healthStatus: mockHealthStatus
 				};
 		}
 	}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,6 +7,14 @@
 	import type { PageProps } from './$types';
 	import { env } from '$env/dynamic/public';
 	import SyncButton from '$lib/components/SyncButton.svelte';
+	import { onMount } from 'svelte';
+	import { checkRegistryHealth } from '$lib/utils/health';
+
+	let isHealthy = $state<boolean | undefined>(undefined);
+
+	onMount(async () => {
+		isHealthy = await checkRegistryHealth(env.PUBLIC_REGISTRY_URL);
+	});
 
 	let { data }: PageProps = $props();
 	const searchQuery = writable('');
@@ -57,10 +65,20 @@
 	{#if data.repos}
 		<div class="flex-1 w-full flex-col justify-between">
 			{#if $repositories.length > 0}
-				<div class="flex justify-between items-center px-10 pt-10">
-					<h2 class="text-2xl">
-						Found {$filteredData.length} Repositories in {env.PUBLIC_REGISTRY_NAME}
-					</h2>
+				<div class="flex justify-between items-start px-10 pt-10">
+					<div class="space-y-2">
+						<h2 class="text-2xl">
+							Found {$filteredData.length} Repositories in {env.PUBLIC_REGISTRY_NAME}
+						</h2>
+						{#if isHealthy !== undefined}
+							<div class="flex items-center gap-2">
+								<div class="w-2 h-2 rounded-full {isHealthy ? 'bg-green-500' : 'bg-red-500'}"></div>
+								<span class="text-sm text-muted-foreground">
+									Registry {isHealthy ? 'Healthy' : 'Unhealthy'}
+								</span>
+							</div>
+						{/if}
+					</div>
 					<div class="flex items-center gap-4">
 						<SyncButton />
 						<div class="relative w-[250px]">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,16 +7,9 @@
 	import type { PageProps } from './$types';
 	import { env } from '$env/dynamic/public';
 	import SyncButton from '$lib/components/SyncButton.svelte';
-	import { onMount } from 'svelte';
-	import { checkRegistryHealth } from '$lib/utils/health';
-
-	let isHealthy = $state<boolean | undefined>(undefined);
-
-	onMount(async () => {
-		isHealthy = await checkRegistryHealth(env.PUBLIC_REGISTRY_URL);
-	});
 
 	let { data }: PageProps = $props();
+	const isHealthy = data.healthStatus.isHealthy;
 	const searchQuery = writable('');
 
 	// Constants

--- a/tests/e2e/registry.spec.ts
+++ b/tests/e2e/registry.spec.ts
@@ -69,13 +69,7 @@ test.describe('Docker Registry UI (Mocked)', () => {
 			throw error; // Re-throw the error to fail the test
 		}
 
-		// Check if PUBLIC_REGISTRY_URL is defined
-		console.log('PUBLIC_REGISTRY_URL:', process.env.PUBLIC_REGISTRY_URL);
-
-		// Wait for the error message to appear
-		await page.waitForSelector('text=/Unable to connect to registry/');
-
-		// Use a regex to match part of the error message since it includes dynamic URL
+		// Check for error message
 		await expect(page.getByText(/Unable to connect to registry/)).toBeVisible();
 	});
 
@@ -84,7 +78,7 @@ test.describe('Docker Registry UI (Mocked)', () => {
 		await page.goto('/?mock=empty');
 		await page.waitForLoadState('networkidle');
 
-		// Update to match actual empty state message
+		// Check for empty state message
 		await expect(page.getByText('Could not pull registry data...')).toBeVisible();
 	});
 });


### PR DESCRIPTION
Fixes: https://github.com/kmendell/svelocker-ui/issues/27

## Summary by Sourcery

This pull request introduces a health check feature for the configured registry. It checks if the registry is healthy and supports the V2 API, and indicates whether authentication is required. The status is displayed in the UI.

New Features:
- Adds a health check for the configured registry to indicate its status in the UI.
- Displays whether the registry requires authentication.

## Summary by Sourcery

This pull request adds a health check feature for the configured registry. It checks if the registry is healthy and supports the V2 API, and indicates whether authentication is required. The status is displayed in the UI. It also improves error handling and adds logging.

New Features:
- Introduces a health check for the configured registry to indicate its status in the UI.
- Displays whether the registry requires authentication.

Enhancements:
- Improves error handling by attempting to return cached data when the registry is unreachable.
- Adds logging to the layout server to provide more information about the registry health check and data fetching process.

Tests:
- Updates existing tests to check for the new error message related to registry connection issues.