### PR TITLE
fix: oci manifest types retrival

### DIFF
--- a/src/lib/utils/manifest.ts
+++ b/src/lib/utils/manifest.ts
@@ -2,14 +2,17 @@ import axios from 'axios';
 import type { ImageMetadata } from '$lib/models/metadata.ts';
 import { env } from '$env/dynamic/public';
 import { Buffer } from 'buffer';
+import { Logger } from '$lib/services/logger';
+import { calculateSha256, filterAttestationManifests } from '$lib/utils/oci-manifest';
+
+const logger = Logger.getInstance('ManifestUtils');
 
 export async function fetchDockerMetadataAxios(registryUrl: string, repo: string, tag: string): Promise<ImageMetadata | undefined> {
+	const logger = Logger.getInstance('ManifestUtils');
 	const manifestUrl = `${registryUrl}/v2/${repo}/manifests/${tag}`;
 
 	try {
 		const auth = Buffer.from(`${env.PUBLIC_REGISTRY_USERNAME}:${env.PUBLIC_REGISTRY_PASSWORD}`).toString('base64');
-
-		// Fetch the manifest JSON with Axios
 		const manifestResponse = await axios.get(manifestUrl, {
 			headers: {
 				Authorization: `Basic ${auth}`,
@@ -18,17 +21,41 @@ export async function fetchDockerMetadataAxios(registryUrl: string, repo: string
 		});
 
 		const manifest = manifestResponse.data;
+		let contentDigest = manifestResponse.headers['docker-content-digest'];
+		let configDigest;
 
-		// Check if the manifest is of type OCI or Docker and handle accordingly
-		const isOciManifest = manifest.mediaType === 'application/vnd.oci.image.index.v1+json';
-		// Extract the content digest from the response headers
-		const contentDigest = manifestResponse.headers['docker-content-digest'];
+		// Handle OCI manifest
+		if (manifest.mediaType === 'application/vnd.oci.image.index.v1+json') {
+			logger.info('OCI manifest detected');
 
-		if (isOciManifest) {
-			// Handle OCI manifest if necessary
+			// Get the first non-attestation manifest
+			const platformManifest = manifest.manifests.find((m: any) => !m.annotations?.['vnd.docker.reference.type']);
+
+			if (!platformManifest) {
+				throw new Error('No valid platform manifest found');
+			}
+
+			// Fetch the platform-specific manifest
+			const platformManifestResponse = await axios.get(`${registryUrl}/v2/${repo}/manifests/${platformManifest.digest}`, {
+				headers: {
+					Authorization: `Basic ${auth}`,
+					Accept: platformManifest.mediaType
+				}
+			});
+
+			// Update configDigest from platform manifest
+			configDigest = platformManifestResponse.data.config?.digest;
+
+			// Calculate content digest for OCI manifest
+			const formattedManifest = JSON.stringify(manifest);
+			const filteredManifest = await filterAttestationManifests(formattedManifest);
+			const hash = await calculateSha256(filteredManifest);
+			logger.info(`Calculated manifest hash: ${hash}`);
+			contentDigest = hash;
+		} else {
+			// Handle regular Docker manifest
+			configDigest = manifest.config?.digest;
 		}
-
-		const configDigest = manifest.config?.digest;
 
 		if (!configDigest) {
 			throw new Error('Config digest not found in manifest.');
@@ -76,7 +103,7 @@ export async function fetchDockerMetadataAxios(registryUrl: string, repo: string
 			entrypoint: entrypoint
 		};
 	} catch (error) {
-		console.error(`Error fetching metadata for ${repo}:${tag}: ${error instanceof Error ? error.message : error}`);
+		logger.error(`Error fetching metadata for ${repo}:${tag}:`, error);
 		return undefined; // Return undefined in case of an error
 	}
 }

--- a/src/lib/utils/oci-manifest.ts
+++ b/src/lib/utils/oci-manifest.ts
@@ -1,0 +1,32 @@
+import { createHash } from 'crypto';
+import { Logger } from '$lib/services/logger';
+
+const logger = Logger.getInstance('OCIManifest');
+
+export async function filterAttestationManifests(manifestJson: string): Promise<string> {
+	const manifest = JSON.parse(manifestJson);
+
+	if (manifest.manifests) {
+		// Filter out attestation manifests
+		manifest.manifests = manifest.manifests.filter((m: any) => !m.annotations?.['vnd.docker.reference.type']);
+
+		// Ensure deterministic ordering
+		manifest.manifests.sort((a: any, b: any) => a.digest.localeCompare(b.digest));
+	}
+
+	// Ensure deterministic JSON stringification
+	return JSON.stringify(manifest, null, 2);
+}
+
+export async function calculateSha256(content: string): Promise<string> {
+	try {
+		const hash = createHash('sha256');
+		// Remove all whitespace and newlines for consistent hashing
+		const normalized = content.replace(/\s/g, '');
+		hash.update(normalized);
+		return `sha256:${hash.digest('hex')}`;
+	} catch (error) {
+		logger.error('Error calculating SHA256:', error);
+		throw error;
+	}
+}

--- a/src/lib/utils/repos.ts
+++ b/src/lib/utils/repos.ts
@@ -16,8 +16,6 @@ export async function getRegistryReposAxios(url: string): Promise<RegistryRepos>
 	try {
 		const auth = Buffer.from(`${env.PUBLIC_REGISTRY_USERNAME}:${env.PUBLIC_REGISTRY_PASSWORD}`).toString('base64');
 
-		// const response = await axios.get(url);
-
 		const response = await axios.get(url, {
 			headers: {
 				Authorization: `Basic ${auth}`,

--- a/src/lib/utils/tags.ts
+++ b/src/lib/utils/tags.ts
@@ -4,14 +4,17 @@ import type { RepoImage } from '$lib/models/image.ts';
 import { fetchDockerMetadataAxios } from '$lib/utils/manifest.ts';
 import { env } from '$env/dynamic/public';
 import { Buffer } from 'buffer';
+import { Logger } from '$lib/services/logger';
 
 export async function getDockerTagsNew(registryUrl: string, repo: string): Promise<RepoImage> {
+	const logger = Logger.getInstance('TagUtils');
 	let tags: ImageTag[] = [];
 	let data: { name: string; tags: string[] } = { name: '', tags: [] };
 
 	try {
 		const auth = Buffer.from(`${env.PUBLIC_REGISTRY_USERNAME}:${env.PUBLIC_REGISTRY_PASSWORD}`).toString('base64');
 
+		logger.debug(`Fetching tags for ${repo}`);
 		const response = await axios.get(`${registryUrl}/v2/${repo}/tags/list`, {
 			headers: {
 				Authorization: `Basic ${auth}`,
@@ -21,25 +24,42 @@ export async function getDockerTagsNew(registryUrl: string, repo: string): Promi
 
 		data = await response.data;
 
+		// Ensure we have a valid name from the repo path
+		const name = data.name || repo.split('/').pop() || '';
+
+		if (!name) {
+			logger.error(`Invalid repository name for ${repo}`);
+			throw new Error('Invalid repository name');
+		}
+
 		if (data.tags) {
+			logger.info(`Found ${data.tags.length} tags for ${repo}`);
 			tags = await Promise.all(
 				data.tags.map(async (tag) => {
-					const metadata = await fetchDockerMetadataAxios(registryUrl, repo, tag);
-					return { name: tag, metadata };
+					try {
+						const metadata = await fetchDockerMetadataAxios(registryUrl, repo, tag);
+						return { name: tag, metadata };
+					} catch (error) {
+						logger.error(`Error fetching metadata for ${repo}:${tag}:`, error);
+						return { name: tag, metadata: undefined };
+					}
 				})
 			);
 		}
-	} catch (error) {
-		console.error('Error fetching repo images:', error);
+
 		return {
-			name: data.name,
+			name: name,
+			fullName: repo,
+			tags
+		};
+	} catch (error) {
+		logger.error('Error fetching repo images:', error);
+		// Ensure we return a valid name even in error cases
+		const fallbackName = repo.split('/').pop() || '';
+		return {
+			name: fallbackName,
 			fullName: repo,
 			tags: []
 		};
 	}
-	return {
-		name: data.name,
-		fullName: repo,
-		tags
-	};
 }


### PR DESCRIPTION
Fixes: https://github.com/kmendell/svelocker-ui/issues/60

## Summary by Sourcery

This pull request introduces support for fetching and processing OCI manifests, fixing an issue where image metadata retrieval was failing for OCI images. It includes changes to handle different manifest types, calculate content digests, and improve error logging.

New Features:
- Adds support for fetching and processing OCI (Open Container Initiative) manifests, including handling platform-specific manifests and calculating content digests.
- Introduces filtering of attestation manifests to ensure only relevant manifests are processed.

Bug Fixes:
- Fixes an issue where OCI manifests were not being correctly processed, leading to errors in retrieving image metadata.

Enhancements:
- Improves error logging by using a logger instance for more detailed and consistent error reporting.
- Refactors manifest processing logic to handle both OCI and Docker manifests, ensuring compatibility with different registry types.

Chores:
- Introduces a new utility module for OCI manifest handling, including functions for filtering and calculating SHA256 hashes.