### PR TITLE
fix: allow for images without a namespace

### DIFF
--- a/src/lib/components/image-table/tag-dropdown-actions.svelte
+++ b/src/lib/components/image-table/tag-dropdown-actions.svelte
@@ -45,7 +45,7 @@
 			<DropdownMenu.Separator />
 			{#each $sortedTags as tag}
 				<DropdownMenu.Item role="menuitem" class="font-bold flex items-center justify-center ">
-					<a href="/details/{imageFullName}/{tag.name}" class={tag.name === 'latest' ? 'text-green-400' : ''}>
+					<a href="/details/{imageFullName.includes('/') ? imageFullName : `library/${imageFullName}`}/{tag.name}" class={tag.name === 'latest' ? 'text-green-400' : ''}>
 						{tag.name}
 					</a>
 				</DropdownMenu.Item>

--- a/src/lib/services/db.ts
+++ b/src/lib/services/db.ts
@@ -70,10 +70,13 @@ export class RegistryCache {
 			db.prepare('DELETE FROM repositories').run();
 
 			for (const repo of repos) {
-				const { lastInsertRowid: repoId } = stmt.run(repo.name);
+				// Use 'library' for root-level images
+				const repoName = repo.name || 'library';
+				const { lastInsertRowid: repoId } = stmt.run(repoName);
 
 				for (const image of repo.images) {
-					const { lastInsertRowid: imageId } = insertImage.run(repoId, image.name, image.fullName);
+					const imageName = image.name || image.fullName.split('/').pop() || '';
+					const { lastInsertRowid: imageId } = insertImage.run(repoId, imageName, image.fullName);
 
 					for (const tag of image.tags) {
 						const { lastInsertRowid: tagId } = insertTag.run(imageId, tag.name, tag.metadata?.configDigest || null);

--- a/src/lib/utils/repos.ts
+++ b/src/lib/utils/repos.ts
@@ -9,6 +9,10 @@ interface RegistryRepos {
 }
 
 function getNamespace(fullName: string): string {
+	// If there's no forward slash, it's a root image
+	if (!fullName.includes('/')) {
+		return 'library'; // Use 'library' as default namespace like Docker Hub
+	}
 	return fullName.split('/')[0];
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -19,8 +19,14 @@
 	// Create a store for the repositories
 	const repositories = writable(data.repos.repositories);
 
-	// Filter data based on search
-	const filteredData = derived([repositories, searchQuery], ([$repositories, $searchQuery]) => $repositories.filter((repo) => repo.name.toLowerCase().includes($searchQuery.toLowerCase())));
+	// Filter data based on search, including root-level images
+	const filteredData = derived([repositories, searchQuery], ([$repositories, $searchQuery]) => {
+		return $repositories.filter((repo) => {
+			const searchTerms = $searchQuery.toLowerCase();
+			// Search in both namespace and image names
+			return repo.name.toLowerCase().includes(searchTerms) || repo.images.some((img) => img.name.toLowerCase().includes(searchTerms));
+		});
+	});
 
 	// Update total pages based on filtered data
 	const totalPages = derived(filteredData, ($filteredData) => Math.ceil($filteredData.length / ITEMS_PER_PAGE));
@@ -61,7 +67,8 @@
 				<div class="flex justify-between items-start px-10 pt-10">
 					<div class="space-y-2">
 						<h2 class="text-2xl">
-							Found {$filteredData.length} Repositories in {env.PUBLIC_REGISTRY_NAME}
+							Found {$filteredData.length}
+							{$filteredData.length === 1 ? 'Repository' : 'Repositories'} in {env.PUBLIC_REGISTRY_NAME}
 						</h2>
 						{#if isHealthy !== undefined}
 							<div class="flex items-center gap-2">

--- a/src/routes/details/[repo]/[image]/[tag]/+page.svelte
+++ b/src/routes/details/[repo]/[image]/[tag]/+page.svelte
@@ -79,12 +79,16 @@
 				<Breadcrumb.Separator>
 					<Slash class="h-4 w-4" />
 				</Breadcrumb.Separator>
-				<Breadcrumb.Item>
-					<Breadcrumb.Link href="/" class="text-muted-foreground hover:text-foreground">{data.repo}</Breadcrumb.Link>
-				</Breadcrumb.Item>
-				<Breadcrumb.Separator>
-					<Slash class="h-4 w-4" />
-				</Breadcrumb.Separator>
+				{#if data.repo !== 'library'}
+					<Breadcrumb.Item>
+						<Breadcrumb.Link href="/" class="text-muted-foreground hover:text-foreground">
+							{data.repo}
+						</Breadcrumb.Link>
+					</Breadcrumb.Item>
+					<Breadcrumb.Separator>
+						<Slash class="h-4 w-4" />
+					</Breadcrumb.Separator>
+				{/if}
 				<Breadcrumb.Item>
 					<Breadcrumb.Link href="/" class="text-muted-foreground hover:text-foreground">{data.imageName}</Breadcrumb.Link>
 				</Breadcrumb.Item>

--- a/tests/e2e/registry.spec.ts
+++ b/tests/e2e/registry.spec.ts
@@ -8,7 +8,7 @@ test.describe('Docker Registry UI (Mocked)', () => {
 
 		// Check basic display
 		await expect(page.getByText('namespace1')).toBeVisible();
-		await expect(page.getByText('Found 1 Repositories in test-registry')).toBeVisible();
+		await expect(page.getByText('Found 1 Repository in test-registry')).toBeVisible();
 
 		// Click the repository and wait longer for animations
 		await page.getByText('namespace1').click();
@@ -18,16 +18,6 @@ test.describe('Docker Registry UI (Mocked)', () => {
 		const tagButton = page.getByTestId('tag-button');
 		await expect(tagButton).toBeVisible();
 		await tagButton.click();
-
-		// Wait for dropdown menu to be visible and stable
-		// const dropdown = page.getByTestId('dropdown-content');
-		// await expect(dropdown).toBeVisible();
-		// await page.waitForTimeout(500); // Wait for animation
-
-		// // Verify the dropdown header and tags
-		// await expect(page.getByText('Tags')).toBeVisible();
-		// await expect(page.getByRole('menuitem').filter({ hasText: 'latest' })).toBeVisible();
-		// await expect(page.getByRole('menuitem').filter({ hasText: 'v1.0.0' })).toBeVisible();
 	});
 
 	// Search test


### PR DESCRIPTION
Default namespace will be 'library' this is only used for svelocker ui purposes.

## Summary by Sourcery

This pull request addresses an issue where images lacking a namespace were not properly handled within the application. It introduces the 'library' namespace as the default for such images, ensuring they are correctly displayed and searchable. Additionally, the pull request enhances the search functionality to include these root-level images and updates the repository display message for better clarity.

Bug Fixes:
- Fixes an issue where images without a namespace were not correctly displayed or linked in the UI, by assigning them to the 'library' namespace.

Enhancements:
- Improves search functionality to include root-level images, allowing users to find images without a specified namespace.
- Updates the display message on the home page to correctly pluralize 'Repository' based on the number of repositories found.