### PR TITLE
fix: deletion logic for all manifest types

### DIFF
--- a/src/lib/models/metadata.ts
+++ b/src/lib/models/metadata.ts
@@ -12,4 +12,6 @@ export type ImageMetadata = {
 	description: string;
 	contentDigest: string;
 	entrypoint: string;
+	indexDigest: string;
+	isOCI: boolean;
 };

--- a/src/lib/services/db.ts
+++ b/src/lib/services/db.ts
@@ -56,19 +56,21 @@ db.exec(`
 `);
 
 export class RegistryCache {
-	private static migrateSchema() {
-		const currentVersion = db.prepare('SELECT version FROM schema_version').get()?.version || 0;
+	private static migrated = false;
 
+	private static migrateSchema() {
+		if (RegistryCache.migrated) return;
+		const currentVersion = db.prepare('SELECT version FROM schema_version').get()?.version || 0;
 		if (currentVersion < 1) {
 			// Add new columns
 			db.exec(`
-        ALTER TABLE tag_metadata ADD COLUMN isOCI BOOLEAN;
-        ALTER TABLE tag_metadata ADD COLUMN indexDigest TEXT;
-        
-        -- Update schema version
-        INSERT OR REPLACE INTO schema_version (version) VALUES (1);
-      `);
+          ALTER TABLE tag_metadata ADD COLUMN isOCI BOOLEAN;
+          ALTER TABLE tag_metadata ADD COLUMN indexDigest TEXT;
+          -- Update schema version
+          INSERT OR REPLACE INTO schema_version (version) VALUES (1);
+        `);
 		}
+		RegistryCache.migrated = true;
 	}
 
 	static async syncFromRegistry(registryData: RegistryRepo[]) {

--- a/src/lib/utils/delete.ts
+++ b/src/lib/utils/delete.ts
@@ -10,15 +10,18 @@ export async function deleteDockerManifestAxios(registryUrl: string, repo: strin
 	try {
 		const auth = Buffer.from(`${env.PUBLIC_REGISTRY_USERNAME}:${env.PUBLIC_REGISTRY_PASSWORD}`).toString('base64');
 
-		const manifestUrl = `${registryUrl}/v2/${repo}/manifests/${contentDigest}`;
+		// Ensure clean digest
+		const cleanDigest = contentDigest.replace(/"/g, '');
+		const manifestUrl = `${registryUrl}/v2/${repo}/manifests/${cleanDigest}`;
+
 		logger?.info(`Deleting manifest: ${manifestUrl}`);
 
-		const headers = {
-			Authorization: `Basic ${auth}`,
-			Accept: 'application/json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json'
-		};
-
-		const response = await axios.delete(manifestUrl, { headers });
+		const response = await axios.delete(manifestUrl, {
+			headers: {
+				Authorization: `Basic ${auth}`,
+				Accept: ['application/vnd.docker.distribution.manifest.v2+json', 'application/vnd.oci.image.index.v1+json', 'application/vnd.oci.image.manifest.v1+json'].join(', ')
+			}
+		});
 
 		if (response.status !== 202) {
 			const error = `Failed to delete manifest: ${response.status}`;

--- a/src/lib/utils/health.ts
+++ b/src/lib/utils/health.ts
@@ -14,7 +14,6 @@ export async function checkRegistryHealth(registryUrl: string): Promise<HealthSt
 	const logger = Logger.getInstance('RegistryHealth');
 
 	try {
-		logger.info(`Checking registry health for ${registryUrl}`);
 		const auth = Buffer.from(`${env.PUBLIC_REGISTRY_USERNAME}:${env.PUBLIC_REGISTRY_PASSWORD}`).toString('base64');
 
 		const response = await axios.get(`${registryUrl}/v2/`, {

--- a/src/lib/utils/tags.ts
+++ b/src/lib/utils/tags.ts
@@ -14,7 +14,6 @@ export async function getDockerTagsNew(registryUrl: string, repo: string): Promi
 	try {
 		const auth = Buffer.from(`${env.PUBLIC_REGISTRY_USERNAME}:${env.PUBLIC_REGISTRY_PASSWORD}`).toString('base64');
 
-		logger.debug(`Fetching tags for ${repo}`);
 		const response = await axios.get(`${registryUrl}/v2/${repo}/tags/list`, {
 			headers: {
 				Authorization: `Basic ${auth}`,

--- a/src/routes/details/[repo]/[image]/[tag]/+page.svelte
+++ b/src/routes/details/[repo]/[image]/[tag]/+page.svelte
@@ -143,7 +143,10 @@
 												return;
 											}
 
-											deleteTagBackend(data.imageFullName, digest);
+											// Strip 'library/' prefix if present
+											const imageName = data.imageFullName.startsWith('library/') ? data.imageFullName.replace('library/', '') : data.imageFullName;
+
+											deleteTagBackend(imageName, digest);
 										}}
 										class={buttonVariants({ variant: 'destructive' })}
 									>

--- a/src/routes/details/[repo]/[image]/[tag]/+page.svelte
+++ b/src/routes/details/[repo]/[image]/[tag]/+page.svelte
@@ -29,7 +29,14 @@
 
 	$: currentTag = data.tag.tags[data.tagIndex];
 
-	async function deleteTagBackend(name: string, configDigest: string) {
+	async function deleteTagBackend(name: string, digest: string) {
+		if (!digest) {
+			toast.error('Error Deleting Docker Tag', {
+				description: 'No digest found for this tag'
+			});
+			return;
+		}
+
 		try {
 			const response = await fetch('/api/manifest/delete', {
 				method: 'POST',
@@ -39,7 +46,8 @@
 				body: JSON.stringify({
 					registryUrl: env.PUBLIC_REGISTRY_URL,
 					repo: name,
-					contentDigest: configDigest
+					digest: digest,
+					manifestType: currentTag.metadata.isOCI ? 'application/vnd.oci.image.index.v1+json' : 'application/vnd.docker.distribution.manifest.v2+json'
 				})
 			});
 
@@ -123,7 +131,24 @@
 								</AlertDialog.Header>
 								<AlertDialog.Footer>
 									<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-									<AlertDialog.Action onclick={() => deleteTagBackend(data.imageFullName, currentTag.metadata.contentDigest)} class={buttonVariants({ variant: 'destructive' })}>Delete</AlertDialog.Action>
+									<AlertDialog.Action
+										onclick={() => {
+											const digest = currentTag.metadata?.indexDigest;
+											console.log('Selected digest:', digest);
+
+											if (!digest) {
+												toast.error('Error Deleting Docker Tag', {
+													description: 'No digest found for this tag'
+												});
+												return;
+											}
+
+											deleteTagBackend(data.imageFullName, digest);
+										}}
+										class={buttonVariants({ variant: 'destructive' })}
+									>
+										Delete
+									</AlertDialog.Action>
 								</AlertDialog.Footer>
 							</AlertDialog.Content>
 						</AlertDialog.Root>


### PR DESCRIPTION
Fixes: https://github.com/kmendell/svelocker-ui/issues/66

## Summary by Sourcery

This pull request fixes the manifest deletion logic to correctly handle both Docker and OCI manifests. It ensures that the digest is properly cleaned before being sent to the registry and adds error handling to prevent deletion failures. It also updates the database schema to include fields necessary for OCI manifest support.

Bug Fixes:
- Fixes an issue where manifest deletion failed due to incorrect digest handling and lack of support for OCI manifests.
- Fixes an issue where the digest was not being properly cleaned before being sent to the registry, causing the deletion to fail.
- Fixes an issue where the UI was not displaying an error message when no digest was found for a tag.

Enhancements:
- Adds support for deleting both Docker and OCI manifests.
- Improves error handling and logging for manifest deletion.
- Adds `isOCI` and `indexDigest` fields to the tag metadata to support OCI manifests.