### PR TITLE
fix(reactive-reload): make sure repo cards get updated on resync

### DIFF
--- a/src/lib/components/SyncButton.svelte
+++ b/src/lib/components/SyncButton.svelte
@@ -1,43 +1,36 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
-	import { Loader2 } from 'lucide-svelte';
-	import { toast } from 'svelte-sonner';
+	import { RefreshCw } from 'lucide-svelte';
+	import { startSync, isSyncing, notifySyncComplete } from '$lib/stores/sync-store';
 
-	let syncing = false;
+	let isLoading = false;
 
-	async function triggerSync() {
-		syncing = true;
+	async function handleSync() {
+		if (isLoading) return;
+
+		isLoading = true;
+		startSync();
+
 		try {
 			const response = await fetch('/api/sync', {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json'
-				},
-				body: JSON.stringify({ fullSync: false }) // Specify full sync if needed
+				method: 'POST'
 			});
 
 			if (!response.ok) {
-				const errorData = await response.json().catch(() => ({ error: 'Unknown error' }));
-				toast.error('Failed to sync Registry', {
-					description: errorData.message || 'Unknown error occurred'
-				});
 				throw new Error('Sync failed');
-			} else {
-				toast.success('Registry Synced successfully');
 			}
+
+			// Notify that sync is complete
+			notifySyncComplete();
 		} catch (error) {
-			console.error('Failed to sync:', error);
+			console.error('Failed to sync registry:', error);
 		} finally {
-			syncing = false;
+			isLoading = false;
 		}
 	}
 </script>
 
-<Button onclick={triggerSync} disabled={syncing}>
-	{#if syncing}
-		<Loader2 class="mr-2 h-4 w-4 animate-spin" />
-		<span>Syncing...</span>
-	{:else}
-		<span>Sync Now</span>
-	{/if}
+<Button variant="outline" size="sm" onclick={handleSync} disabled={isLoading} class="gap-1">
+	<RefreshCw size={16} class="opacity-70 {isLoading ? 'animate-spin' : ''}" />
+	Sync Registry
 </Button>

--- a/src/lib/stores/sync-store.ts
+++ b/src/lib/stores/sync-store.ts
@@ -1,0 +1,14 @@
+// src/lib/stores/syncStore.ts
+import { writable } from 'svelte/store';
+
+export const lastSyncTimestamp = writable<number>(Date.now());
+export const isSyncing = writable<boolean>(false);
+
+export function notifySyncComplete() {
+	lastSyncTimestamp.set(Date.now());
+	isSyncing.set(false);
+}
+
+export function startSync() {
+	isSyncing.set(true);
+}

--- a/tests/e2e/registry.spec.ts
+++ b/tests/e2e/registry.spec.ts
@@ -5,7 +5,7 @@ test.describe('Registry UI with Real Registry', () => {
 		// Go to the home page
 		await page.goto('/');
 
-		await page.getByRole('button', { name: 'Sync Now' }).click();
+		await page.getByRole('button', { name: 'Sync Registry' }).click();
 
 		await page.waitForTimeout(500);
 


### PR DESCRIPTION
Fixes: https://github.com/kmendell/svelocker-ui/issues/88

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where repository cards were not updated after a registry resync by ensuring the page data is reloaded upon sync completion.