### PR TITLE
feat(details): add copy run command button

### DIFF
--- a/src/routes/details/[repo]/[image]/[tag]/+page.svelte
+++ b/src/routes/details/[repo]/[image]/[tag]/+page.svelte
@@ -52,6 +52,27 @@
 		}
 	});
 
+	async function copyDockerRunCommand() {
+		let registryHost = '';
+		try {
+			const url = new URL(env.PUBLIC_REGISTRY_URL);
+			registryHost = url.host;
+		} catch (e) {
+			// Fallback if URL parsing fails
+			registryHost = env.PUBLIC_REGISTRY_URL.replace(/^https?:\/\//, '');
+		}
+
+		const dockerRunCmd = `docker run ${registryHost}/${data.imageFullName}:${currentTag.name}`;
+
+		copyTextToClipboard(dockerRunCmd).then((success) => {
+			if (success) {
+				toast.success('Docker Run command copied to clipboard');
+			} else {
+				toast.error('Failed to copy Docker Run command');
+			}
+		});
+	}
+
 	async function deleteTagBackend(name: string, digest: string) {
 		if (!digest) {
 			toast.error('Error Deleting Docker Tag', {
@@ -193,7 +214,14 @@
 						{#if currentTag.metadata}
 							<div class="space-y-2">
 								<p class="text-lg text-muted-foreground">{currentTag.metadata.description}</p>
-								<p class="text-sm text-muted-foreground font-mono">{currentTag.metadata?.indexDigest || ''}</p>
+								<div class="flex flex-col gap-2">
+									<p class="text-sm text-muted-foreground font-mono">{currentTag.metadata?.indexDigest || ''}</p>
+									<!-- Add the Docker Run Command button here -->
+									<Button variant="outline" size="sm" class="gap-2 mt-5 w-fit" onclick={copyDockerRunCommand}>
+										<Terminal class="h-4 w-4" />
+										Copy Docker Run Command
+									</Button>
+								</div>
 							</div>
 						{/if}
 					</div>
@@ -224,10 +252,12 @@
 							<h2 class="text-lg font-semibold">Dockerfile</h2>
 							<p class="text-sm text-muted-foreground">Viewing Dockerfile for {data.imageFullName}:{currentTag.name}</p>
 						</div>
-						<Button variant="outline" size="sm" class="gap-2 dockerButton" onclick={copyDockerfile}>
-							<Copy class="h-4 w-4" />
-							Copy
-						</Button>
+						<div class="flex gap-2">
+							<Button variant="outline" size="sm" class="gap-2 dockerButton" onclick={copyDockerfile}>
+								<Copy class="h-4 w-4" />
+								Copy Dockerfile
+							</Button>
+						</div>
 					</div>
 					<div class="relative">
 						<pre class="flex text-sm font-mono leading-relaxed">


### PR DESCRIPTION
Fixes: https://github.com/kmendell/svelocker-ui/issues/90

## Summary by Sourcery

New Features:
- Adds a button to the image details page that copies the docker run command to the clipboard.